### PR TITLE
Update sqlite version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,11 @@
 source "https://rubygems.org"
 
 # Database
-gem 'sqlite3', '~>1.4'
+gem 'sqlite3', '~>1.6'
 
 # Testing
 gem 'rspec'
 
 # Debugging
 gem 'pry'
+gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    ast (2.4.3)
     coderay (1.1.2)
     diff-lcs (1.3)
+    json (2.13.2)
+    language_server-protocol (3.17.0.5)
+    lint_roller (1.1.0)
     method_source (0.9.2)
+    mini_portile2 (2.8.9)
+    parallel (1.27.0)
+    parser (3.3.9.0)
+      ast (~> 2.4.1)
+      racc
+    prism (1.4.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    regexp_parser (2.11.2)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -20,7 +33,26 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    sqlite3 (1.4.2)
+    rubocop (1.80.2)
+      json (~> 2.3)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.1.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.9.3, < 3.0)
+      rubocop-ast (>= 1.46.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 4.0)
+    rubocop-ast (1.46.0)
+      parser (>= 3.3.7.2)
+      prism (~> 1.4)
+    ruby-progressbar (1.13.0)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    unicode-display_width (3.1.5)
+      unicode-emoji (~> 4.0, >= 4.0.4)
+    unicode-emoji (4.0.4)
 
 PLATFORMS
   ruby
@@ -28,7 +60,8 @@ PLATFORMS
 DEPENDENCIES
   pry
   rspec
-  sqlite3 (~> 1.4)
+  rubocop
+  sqlite3 (~> 1.6)
 
 BUNDLED WITH
    2.2.23


### PR DESCRIPTION
This pull request updates the `Gemfile` to improve dependency management and code quality tools.

Dependency updates:

* Updated the `sqlite3` gem version from `~>1.4` to `~>1.6` to ensure compatibility with newer features and bug fixes.

Development tool additions:

* Added the `rubocop` gem to support automated code style and linting checks.